### PR TITLE
fix bug where retmode is not passed down to make_entrez_query in entr…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: rentrez
-Version: 1.1.0
+Version: 1.1.1
 Date: 2017-05-22
 Title: Entrez in R
 Authors@R: c(

--- a/R/entrez_fetch.r
+++ b/R/entrez_fetch.r
@@ -54,7 +54,7 @@ entrez_fetch <- function(db, id=NULL, web_history=NULL, rettype, retmode="", par
           stop(msg)
         }
     }
-    args <- c(list("efetch", db=db, rettype=rettype, config=config, ...), identifiers) 
+    args <- c(list("efetch", db=db, rettype=rettype, config=config, retmode=retmode, ...), identifiers) 
     records <- do.call(make_entrez_query, args) 
     #NCBI limits requests to three per second
     Sys.sleep(0.33)


### PR DESCRIPTION
The retmode parameter is ignored in entrez_fetch, which causes xml to be returned when a genbank file was asked for. This breaks integration with genbankr. If you could push a narrow bugfix to cran for this soon I would appreciate it, as genbankr is going to continue to fail in the Bioc build system until either this is fixed or I disable the integration (which Id on't want to do, since I think it's a very powerful feature).

I went ahead and bumped the version in the DESCRIPTION file because I need to be able to put a versioned dependency in genbankr, but if you'd prefer those happen  separately I can recreate the PR without that.
