### PR TITLE
Fix sleep_time causing API rate limit exceeded

### DIFF
--- a/R/base.r
+++ b/R/base.r
@@ -83,7 +83,7 @@ sleep_time <- function(argument_list){
     if("api_key" %in% names(argument_list)){
         return(0.1)
     }
-    1/3
+    0.34 
 }
 ##
 # Check for that we have either the ID or the web-history functions are 


### PR DESCRIPTION
When `api_key` is not provided, Entrez allows 3 requests per second, thus `sleep_time` should be at least (1/3) second. Rounding error caused it to wait for less than (1/3), resulting in _API rate limit exceeded_ error. Fix it into 0.34.