### PR TITLE
make entrez_search() use POST (and some minor typo fixes)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Development Version
+-----------------
+
+* A fix to #163 forces the use of POST for `entrez_search()` so that long query
+  strings do not get the HTTP 414 error (thanks to @billdenney for the fix).
+
 Version 1.2.3
 -----------------
 Maintenance release, mostly to prevent issues with rate-limiting errors when the
@@ -5,7 +11,7 @@ package is tested in CRAN.
 
 * The sleep commands for rate-limiting are slightly increased
 
-* As of this release, the vignette is NOT build by default (to avoid issues with
+* As of this release, the vignette is NOT built by default (to avoid issues with
   automated tests on CRAN). This will not affect most users, but a developers
   may want to read a wiki page describing how to build the vignette:
 

--- a/R/entrez_search.r
+++ b/R/entrez_search.r
@@ -74,6 +74,7 @@ entrez_search <- function(db, term, config=NULL, retmode="xml", use_history=FALS
                                   config=config,
                                   retmode=retmode, 
                                   usehistory=usehistory,
+                                  use_post=TRUE,
                                   ...)
     parsed <- parse_response(response, retmode)
     parse_esearch(parsed, history=use_history)


### PR DESCRIPTION
This fixes #163.

It causes `entrez_search()` to use HTTP POST instead of GET for all calls.  This doesn't appear to have a downside, and all tests passed.  I did not simply force all requests to go through POST since I assumed that there was a reason for only testing the `ids` argument and using GET for some calls.