### PR TITLE
FIX: entrez_post does not use POST method for >200 IDs

### DIFF
--- a/R/base.r
+++ b/R/base.r
@@ -36,6 +36,7 @@ make_entrez_query <- function(util, config, interface=".fcgi?", by_id=FALSE, deb
             args$api_key <- Sys.getenv('ENTREZ_KEY')
         }
     }
+    id_length <- length(args$id)
     if("id" %in% names(args)){
         if(by_id){
             ids_string <- paste0("id=", args$id, collapse="&")
@@ -66,7 +67,7 @@ make_entrez_query <- function(util, config, interface=".fcgi?", by_id=FALSE, deb
     }
 
     
-    if(length(args$id) > 200){ 
+    if(id_length > 200){
         response <- httr::POST(uri, body=args, config= config)
     } else {
         response <- httr::GET(uri, query=args, config= config) 


### PR DESCRIPTION
When `args$id` is present as input to `make_entrez_query()` (e.g. from `entrez_post`) the IDs are collapsed to a string (length = 1) before `args$id length > 200` is used to determine whether to use the POST method. It always uses the GET method because it's always length <= 1.

This is a minor change that fixes this issue. It passes your testthat::test() with 4 warnings. May need to be combined with PR #164 if implementing fix for Issue #163.

### Reprex - Original code

```
library(rentrez)

pmid <- 25348409

# Get PubMed articles PMIDs that cite pmid (234)
citedin_pmids <- rentrez::entrez_link(
    dbfrom = "pubmed",
    id = pmid,
    db = "pubmed",
    linkname = "pubmed_pubmed_citedin"
)$links$pubmed_pubmed_citedin


# Try to create web history with epost ------------------------------------

# even GET method works above 200 (using 234 IDs)
rentrez::entrez_post(
    db = "pubmed",
    id = citedin_pmids,
    web_history = NULL
)
#> Web history object (QueryKey = 1, WebEnv = MCID_6127c75...)

# but not around ~500 (using 468 IDs)
ids_rep2 <- rep(citedin_pmids, 2)
rentrez::entrez_post(
    db = "pubmed",
    id = ids_rep2,
    web_history = NULL
)
#> Error in entrez_check(response): HTTP failure 414, the request is too large. For large requests, try using web history as described in the rentrez tutorial
```
_Created on 2021-08-26 by the [reprex package](https://reprex.tidyverse.org/) (v2.0.1)_


### Reprex - After fix
```
library(rentrez)

pmid <- 25348409

# Get PubMed articles PMIDs that cite pmid (234)
citedin_pmids <- rentrez::entrez_link(
    dbfrom = "pubmed",
    id = pmid,
    db = "pubmed",
    linkname = "pubmed_pubmed_citedin"
)$links$pubmed_pubmed_citedin


# Try to create web history with epost ------------------------------------

# even GET method works above 200 (using 234 IDs)
rentrez::entrez_post(
    db = "pubmed",
    id = citedin_pmids,
    web_history = NULL
)
#> Web history object (QueryKey = 1, WebEnv = MCID_6127cb8...)

# but not around ~500 (using 468 IDs) --> NOW WORKS
ids_rep2 <- rep(citedin_pmids, 2)
rentrez::entrez_post(
    db = "pubmed",
    id = ids_rep2,
    web_history = NULL
)
#> Web history object (QueryKey = 1, WebEnv = MCID_6127cb8...)
```
_Created on 2021-08-26 by the [reprex package](https://reprex.tidyverse.org/) (v2.0.1)_