### PR TITLE
fixed typos for CRAN 

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,14 +9,14 @@ We love collaboration.
 
 ## Code/Documentation contributions
 
-###Scope 
+### Scope 
 
 We would love to have your help in developing `rentrez`. Bear in mind, `rentrez`
 is intended to be a general-purpose wrapper for the `Eutils` API. Functions that
 make use of `rentrez` to perform more specific tasks should be added to existing
 packages, or form the basis of new ones. 
 
-###Perferred way to contribute code
+### Perferred way to contribute code
 
 * Fork this repo to your Github account
 * Clone your version on your account down to your machine from your account, e.g,. `git clone https://github.com/<yourgithubusername>/rentrez.git`

--- a/R/entrez_fetch.r
+++ b/R/entrez_fetch.r
@@ -3,7 +3,7 @@
 #' Pass unique identifiers to an NCBI database and receive data files in a
 #' variety of formats.
 #
-#' A set of unique identifiers mustbe specified with either the \code{db}
+#' A set of unique identifiers must be specified with either the \code{db}
 #' argument (which directly specifies the IDs as a numeric or character vector)
 #' or a \code{web_history} object as returned by 
 #' \code{\link{entrez_link}}, \code{\link{entrez_search}} or 

--- a/R/entrez_link.r
+++ b/R/entrez_link.r
@@ -7,29 +7,29 @@
 #'
 #'@export
 #'@param db character Name of the database to search for links (or use "all" to 
-#' search all databases available for \code{db}. \code{entrez_db_links} allows you
+#' search all databases available for \code{db}). \code{entrez_db_links} allows you
 #' to discover databases that might have linked information (see examples).
 #'@param id vector with unique ID(s) for records in database \code{db}. 
 #'@param web_history a web_history object  
 #'@param dbfrom character Name of database from which the Id(s) originate
 #'@param by_id logical If FALSE (default) return a single 
-#' \code{elink} objects containing links for all of the provided \code{id}s. 
+#' \code{elink} object containing links for all of the provided \code{id}s. 
 #' Alternatively, if TRUE return a list of \code{elink} objects, one for each 
 #' ID in \code{id}. 
 #'@param cmd link function to use. Allowed values include
 #' \itemize{
 #'   \item neighbor (default). Returns a set of IDs in \code{db} linked to the
 #'   input IDs in \code{dbfrom}.
-#'   \item neighbor_score. As `neighbor'', but additionally returns similarity scores.
-#'   \item neighbor_history. As `neighbor', but returns web history objects.
+#'   \item neighbor_score. As `neighbor`, but additionally returns similarity scores.
+#'   \item neighbor_history. As `neighbor`, but returns web history objects.
 #'   \item acheck. Returns a list of linked databases available from NCBI for a set of IDs.
 #'   \item ncheck. Checks for the existence of links within a single database.
 #'   \item lcheck. Checks for external (i.e. outside NCBI) links.
 #'   \item llinks. Returns a list of external links for each ID, excluding links
 #'   provided by libraries.
-#'   \item llinkslib. As 'llinks' but additionally includes links provided by
+#'   \item llinkslib. As `llinks` but additionally includes links provided by
 #'   libraries.
-#'   \item prlinks. As 'llinks' but returns only the primary external link for
+#'   \item prlinks. As `llinks` but returns only the primary external link for
 #'   each ID.
 #'}
 #'@param \dots character Additional terms to add to the request, see NCBI

--- a/R/entrez_search.r
+++ b/R/entrez_search.r
@@ -19,7 +19,7 @@
 #'
 #' The\code{rentrez} tutorial provides some tips on how to make the most of 
 #' searches to the NCBI. In particular, the sections on uses of the "Filter"
-#' field and MeSH terms may in formulating precise searches. 
+#' field and MeSH terms may help in formulating precise searches.
 #' 
 #'@export
 #'@param db character, name of the database to search for.
@@ -61,7 +61,7 @@
 #' #Oh, right. There is a genus and a subgenus name Drosophila...
 #' #how can we limit this search
 #' (tax_fields <- entrez_db_searchable("taxonomy"))
-#' #"RANK" loots promising
+#' #"RANK" looks promising
 #' tax_fields$RANK
 #' entrez_search(db="taxonomy", term="Drosophila & Genus[RANK]")
 #'}

--- a/R/entrez_summary.r
+++ b/R/entrez_summary.r
@@ -29,7 +29,7 @@
 #'@param db character Name of the database to search for
 #'@param id vector with unique ID(s) for records in database \code{db}.
 #' In the case of sequence databases these IDs can take form of an
-#' NCBI accession followed by a version number (eg AF123456.1 or AF123456.2)
+#' NCBI accession followed by a version number (e.g. AF123456.1 or AF123456.2)
 #'@param web_history A web_history object 
 #'@param always_return_list logical, return a list  of esummary objects even
 #'when only one ID is provided (see description for a note about this option)
@@ -44,7 +44,7 @@
 #'@seealso \code{\link{extract_from_esummary}} which can be used to extract
 #'elements from a list of esummary records
 #'@return A list of esummary records (if multiple IDs are passed and
-#'always_return_list if FALSE) or a single record.
+#'always_return_list is FALSE) or a single record.
 #'@return file XMLInternalDocument xml file containing the entire record
 #'returned by the NCBI.
 #'@importFrom XML xpathApply xmlSApply xmlGetAttr xmlValue
@@ -163,7 +163,7 @@ parse_esummary.XMLInternalDocument  <- function(x, version, always_return_list){
         recs <- x["//DocSum"] 
 
         if(length(recs)==0){
-           stop("Esummary document contains no DocSums, try 'version=2.0'?)")
+           stop("Esummary document contains no DocSums, try 'version=2.0'?")
         }
         per_rec <- function(r){
             res <- xpathApply(r, "Item", parse_node)

--- a/R/help.r
+++ b/R/help.r
@@ -7,10 +7,10 @@
 #' documented: \url{https://www.ncbi.nlm.nih.gov/books/NBK25500/}
 #'
 #' The NCBI will ban IPs that don't use EUtils within their \href{https://www.ncbi.nlm.nih.gov/corehtml/query/static/eutils_help.html}{user guidelines}. In particular
-#' /enumerated{
-#'  /item  Don't send more than three request per second (rentrez enforces this limit)
-#'  /item  If you plan on sending a sequence of more than ~100 requests, do so outside of peak times for the US
-#'  /item  For large requests use the web history method (see examples for \code{\link{entrez_search}} or use \code{\link{entrez_post}} to upload IDs)
+#' \enumerate{
+#'  \item  Don't send more than three request per second (rentrez enforces this limit)
+#'  \item  If you plan on sending a sequence of more than ~100 requests, do so outside of peak times for the US
+#'  \item  For large requests use the web history method (see examples for \code{\link{entrez_search}} or use \code{\link{entrez_post}} to upload IDs)
 #'}
 #' @docType package
 #' @name rentrez

--- a/man/entrez_fetch.Rd
+++ b/man/entrez_fetch.Rd
@@ -47,7 +47,7 @@ rettype is a flavour of XML.
 \description{
 Pass unique identifiers to an NCBI database and receive data files in a
 variety of formats.
-A set of unique identifiers mustbe specified with either the \code{db}
+A set of unique identifiers must be specified with either the \code{db}
 argument (which directly specifies the IDs as a numeric or character vector)
 or a \code{web_history} object as returned by 
 \code{\link{entrez_link}}, \code{\link{entrez_search}} or 

--- a/man/entrez_link.Rd
+++ b/man/entrez_link.Rd
@@ -23,28 +23,28 @@ entrez_link(
 \item{id}{vector with unique ID(s) for records in database \code{db}.}
 
 \item{db}{character Name of the database to search for links (or use "all" to 
-search all databases available for \code{db}. \code{entrez_db_links} allows you
+search all databases available for \code{db}). \code{entrez_db_links} allows you
 to discover databases that might have linked information (see examples).}
 
 \item{cmd}{link function to use. Allowed values include
 \itemize{
   \item neighbor (default). Returns a set of IDs in \code{db} linked to the
   input IDs in \code{dbfrom}.
-  \item neighbor_score. As `neighbor'', but additionally returns similarity scores.
-  \item neighbor_history. As `neighbor', but returns web history objects.
+  \item neighbor_score. As `neighbor`, but additionally returns similarity scores.
+  \item neighbor_history. As `neighbor`, but returns web history objects.
   \item acheck. Returns a list of linked databases available from NCBI for a set of IDs.
   \item ncheck. Checks for the existence of links within a single database.
   \item lcheck. Checks for external (i.e. outside NCBI) links.
   \item llinks. Returns a list of external links for each ID, excluding links
   provided by libraries.
-  \item llinkslib. As 'llinks' but additionally includes links provided by
+  \item llinkslib. As `llinks` but additionally includes links provided by
   libraries.
-  \item prlinks. As 'llinks' but returns only the primary external link for
+  \item prlinks. As `llinks` but returns only the primary external link for
   each ID.
 }}
 
 \item{by_id}{logical If FALSE (default) return a single 
-\code{elink} objects containing links for all of the provided \code{id}s. 
+\code{elink} object containing links for all of the provided \code{id}s. 
 Alternatively, if TRUE return a list of \code{elink} objects, one for each 
 ID in \code{id}.}
 

--- a/man/entrez_search.Rd
+++ b/man/entrez_search.Rd
@@ -68,7 +68,7 @@ so there is no need to include these in search term
 
 The\code{rentrez} tutorial provides some tips on how to make the most of 
 searches to the NCBI. In particular, the sections on uses of the "Filter"
-field and MeSH terms may in formulating precise searches.
+field and MeSH terms may help in formulating precise searches.
 }
 \examples{
 \dontrun{
@@ -85,7 +85,7 @@ fly_id <- entrez_search(db="taxonomy", term="Drosophila")
 #Oh, right. There is a genus and a subgenus name Drosophila...
 #how can we limit this search
 (tax_fields <- entrez_db_searchable("taxonomy"))
-#"RANK" loots promising
+#"RANK" looks promising
 tax_fields$RANK
 entrez_search(db="taxonomy", term="Drosophila & Genus[RANK]")
 }

--- a/man/entrez_summary.Rd
+++ b/man/entrez_summary.Rd
@@ -20,7 +20,7 @@ entrez_summary(
 
 \item{id}{vector with unique ID(s) for records in database \code{db}.
 In the case of sequence databases these IDs can take form of an
-NCBI accession followed by a version number (eg AF123456.1 or AF123456.2)}
+NCBI accession followed by a version number (e.g. AF123456.1 or AF123456.2)}
 
 \item{web_history}{A web_history object}
 
@@ -39,7 +39,7 @@ documentation linked to in references for a complete list}
 }
 \value{
 A list of esummary records (if multiple IDs are passed and
-always_return_list if FALSE) or a single record.
+always_return_list is FALSE) or a single record.
 
 file XMLInternalDocument xml file containing the entire record
 returned by the NCBI.

--- a/man/rentrez.Rd
+++ b/man/rentrez.Rd
@@ -14,9 +14,9 @@ Users are expected to know a little bit about the EUtils API, which is well
 documented: \url{https://www.ncbi.nlm.nih.gov/books/NBK25500/}
 
 The NCBI will ban IPs that don't use EUtils within their \href{https://www.ncbi.nlm.nih.gov/corehtml/query/static/eutils_help.html}{user guidelines}. In particular
-/enumerated{
- /item  Don't send more than three request per second (rentrez enforces this limit)
- /item  If you plan on sending a sequence of more than ~100 requests, do so outside of peak times for the US
- /item  For large requests use the web history method (see examples for \code{\link{entrez_search}} or use \code{\link{entrez_post}} to upload IDs)
+\enumerate{
+ \item  Don't send more than three request per second (rentrez enforces this limit)
+ \item  If you plan on sending a sequence of more than ~100 requests, do so outside of peak times for the US
+ \item  For large requests use the web history method (see examples for \code{\link{entrez_search}} or use \code{\link{entrez_post}} to upload IDs)
 }
 }

--- a/tests/testthat/test_search.r
+++ b/tests/testthat/test_search.r
@@ -12,7 +12,7 @@ test_that("Global query works",{
     #global query
     expect_that(gsearch, is_a("numeric"))
     expect_that(names(gsearch), is_a("character"))
-    #now includes 'database error' for some databaes
+    #now includes 'database error' for some database
     #these are made NA in entrez_global_query, which seems reasonable
     expect_true(sum(gsearch, na.rm=TRUE) > 0 )
 })


### PR DESCRIPTION
Hi!

I saw that the 1.2.3 version failed its CRAN checks due to some typo in the documentation. CRAN gives some harsh deadline on fixing this, so I thought of stepping in.

https://cran.r-project.org/web/checks/check_results_rentrez.html
```
Version: 1.2.3
Check: Rd files
Result: NOTE 
  checkRd: (-1) rentrez.Rd:17-21: Lost braces
      17 | /enumerated{
         |            ^
```

There was just a misplaced single quote, so I've fixed that and all other typos I've came across and then re-build the documentation with `devtools::document(roclets = c('rd'))`

Please review if the fixes help.

Thanks, 
Phillip