### PR TITLE
Fix test-suite regression and make live-API tests resilient

### DIFF
--- a/tests/testthat/test_docs.r
+++ b/tests/testthat/test_docs.r
@@ -4,15 +4,14 @@
 context("documentation")
 
 test_that("Examples in documentation work", {
-    #setup
-    hox_paper <- entrez_search(db="pubmed", term="10.1038/nature08789[doi]")
-    katipo_search <- entrez_search(term="Latrodectus katipo[Organism]", 
-                                   term="Latrodectus katipo[Organism]")
-    
+    #setup (guarded so transient NCBI problems skip rather than fail)
+    setup <- tryCatch({
+        list(
+            hox_paper = entrez_search(db="pubmed", term="10.1038/nature08789[doi]"),
+            katipo_search = entrez_search(db="popset", term="Latrodectus katipo[Organism]")
+        )
+    }, error = function(e) skip(paste("NCBI not available:", conditionMessage(e))))
 
-
-    expect_that(hox_paper$ids, equals("20203609"))
-    expect_true(katipo_search$count >= 6)
+    expect_that(setup$hox_paper$ids, equals("20203609"))
+    expect_true(setup$katipo_search$count >= 6)
 })
-
-    

--- a/tests/testthat/test_fetch.r
+++ b/tests/testthat/test_fetch.r
@@ -2,36 +2,47 @@ context("fetching records")
 
 
 pop_ids = c("307082412", "307075396", "307075338", "307075274")
-coi <- entrez_fetch(db = "popset", id = pop_ids[1], 
-                    rettype = "fasta")
-xml_rec <- entrez_fetch(db = "popset", id=pop_ids[1], rettype="native", retmode="xml", parsed=TRUE)
-raw_rec <- entrez_fetch(db = "popset", id=pop_ids[1], rettype="native", retmode="xml")
-
 acc_old = "AF123456.1"
 acc_new = "AF123456.2"
 
+#setup (guarded so transient NCBI problems skip rather than abort the file)
+ncbi_ok <- tryCatch({
+    coi <- entrez_fetch(db = "popset", id = pop_ids[1],
+                        rettype = "fasta")
+    xml_rec <- entrez_fetch(db = "popset", id=pop_ids[1], rettype="native", retmode="xml", parsed=TRUE)
+    raw_rec <- entrez_fetch(db = "popset", id=pop_ids[1], rettype="native", retmode="xml")
+    TRUE
+}, error = function(e) {
+    message("NCBI not available: ", conditionMessage(e))
+    FALSE
+})
+
 test_that("httr does no warn about inferred encoding", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_message( entrez_fetch(db = "popset", id=pop_ids[1], rettype="uilist"), NA)
 })
 
 
 
 test_that("Fetching sequences works", {
+     skip_if(!ncbi_ok, "NCBI not available")
      expect_that(length(strsplit(coi, ">")[[1]]), equals(30))
-          
+
 })
 
 test_that("Entrez_fetch record parsing works", {
+     skip_if(!ncbi_ok, "NCBI not available")
      expect_that(raw_rec, is_a("character"))
      expect_that(xml_rec, is_a("XMLInternalDocument"))
-     expect_error( 
-       entrez_fetch(db="popset", id="307082412", rettype="fasta", parsed=TRUE), 
+     expect_error(
+       entrez_fetch(db="popset", id="307082412", rettype="fasta", parsed=TRUE),
        "At present, entrez_fetch can only parse XML records, got fasta"
      )
 })
 
 
 test_that("Entrez fetch can download versioned sequences", {
+    skip_if(!ncbi_ok, "NCBI not available")
     #The two versions of this sequence have different annotations. We can check
     #that we are getting the correct version of the record by checking the name
     #of each sequence reflects the change in annotation.
@@ -40,5 +51,3 @@ test_that("Entrez fetch can download versioned sequences", {
     expect_match(old_rec, "testis-specific mRNA")
     expect_match(new_rec, "doublesex and mab-3 related transcription factor")
 })
-
-                           

--- a/tests/testthat/test_httr_post.r
+++ b/tests/testthat/test_httr_post.r
@@ -1,19 +1,28 @@
 context("POST (the HTTP verb)")
 
-are_there_any_cancer_papers <- entrez_search(db="pubmed", term="Cancer", retmax=201)
-search_ids <- are_there_any_cancer_papers$ids
+#setup (guarded so transient NCBI problems skip rather than abort the file)
+ncbi_ok <- tryCatch({
+    are_there_any_cancer_papers <- entrez_search(db="pubmed", term="Cancer", retmax=201)
+    search_ids <- are_there_any_cancer_papers$ids
+    TRUE
+}, error = function(e) {
+    message("NCBI not available: ", conditionMessage(e))
+    FALSE
+})
 
 test_that("We can POST to NCBI epost", {
+    skip_if(!ncbi_ok, "NCBI not available")
     wh <- entrez_post(db="pubmed", id=search_ids)
     expect_that(wh, is_a("web_history"))
     expect_that(as.integer(wh$QueryKey), is_a("integer"))
-    expect_false(is.na(as.integer(wh$QueryKey)))    
+    expect_false(is.na(as.integer(wh$QueryKey)))
 })
 
 test_that("We can fecth using POST", {
+    skip_if(!ncbi_ok, "NCBI not available")
     fetched_ids <- entrez_fetch(db="pubmed", id=search_ids, rettype="uilist")
-    expect( 
-        all( strsplit(fetched_ids, "\n")[[1]] %in% search_ids), 
+    expect(
+        all( strsplit(fetched_ids, "\n")[[1]] %in% search_ids),
         "fetched IDs do not match sent IDs when using httr::POST"
     )
 })

--- a/tests/testthat/test_info.r
+++ b/tests/testthat/test_info.r
@@ -1,17 +1,29 @@
 context("einfo functions")
 
-einfo_rec <- entrez_info()
-pm_rec <- entrez_info(db="pubmed")
+#setup (guarded so transient NCBI problems skip rather than abort the file)
+ncbi_ok <- tryCatch({
+    einfo_rec <- entrez_info()
+    pm_rec <- entrez_info(db="pubmed")
+    dbs <- entrez_dbs()
+    cdd <- entrez_db_summary("cdd")
+    search_fields <- entrez_db_searchable("pmc")
+    sf_df <- as.data.frame(search_fields)
+    omim_links <- entrez_db_links("omim")
+    omim_df <- as.data.frame(omim_links)
+    TRUE
+}, error = function(e) {
+    message("NCBI not available: ", conditionMessage(e))
+    FALSE
+})
 
 test_that(" can get xml recs from einfo", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_that(einfo_rec, is_a("XMLInternalDocument"))
     expect_that(pm_rec, is_a("XMLInternalDocument"))
 })
 
-dbs <- entrez_dbs()
-cdd <- entrez_db_summary("cdd")
-
 test_that(" We can get summary information on DBs", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_that(dbs, is_a("character"))
     expect_true("pubmed" %in% dbs)
 
@@ -19,31 +31,29 @@ test_that(" We can get summary information on DBs", {
     expect_named(cdd)
 })
 
-search_fields <- entrez_db_searchable("pmc")
-sf_df <- as.data.frame(search_fields)
-
 test_that("We can retrieve serach fields", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_that(search_fields, is_a("eInfoSearch"))
     expect_named(search_fields$GRNT)
     expect_that(sf_df, is_a("data.frame"))
 })
 
-omim_links <- entrez_db_links("omim")
-omim_df <- as.data.frame(omim_links)
-
 test_that("We can retreive linked dbs", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_that(omim_links, is_a("eInfoLink"))
-    expect_named(omim_links[[1]])    
+    expect_named(omim_links[[1]])
     expect_that(omim_df, is_a("data.frame"))
     expect_equal(nrow(omim_df), length(omim_links))
 })
 
 test_that("We can prink elink objects", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_output(print(omim_links), "Databases with linked records for database 'omim'")
     expect_output(print(search_fields), "Searchable fields for database 'pmc'")
 })
 
 test_that("We can print elements from einfo object", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_output(print(omim_links$gene), "Name: omim_gene\n")
     expect_output(print(search_fields$GRNT), "Name: GRNT\n")
     expect_output(print(cdd), "DbName: cdd")

--- a/tests/testthat/test_link.r
+++ b/tests/testthat/test_link.r
@@ -1,23 +1,25 @@
 context("elink")
 
-elinks_mixed <- entrez_link(dbfrom = "pubmed", id = c(19880848, 22883857), db = "all")
-elinks_by_id <- entrez_link(dbfrom = "pubmed", id = c(19880848, 22883857), db = "all", by_id=TRUE)
-
-
-#
-#We should maybe download these xmls and test the internal functions
-# as these really take some downloading,... especially the lib. links?
-
+#setup (guarded so transient NCBI problems skip rather than abort the file)
 message("(this may take some time, have to download many records)")
-commands <- c("neighbor_history", "neighbor_score", 
-              "acheck", "ncheck", "lcheck", 
+commands <- c("neighbor_history", "neighbor_score",
+              "acheck", "ncheck", "lcheck",
               "llinks", "llinkslib", "prlinks")
 
+ncbi_ok <- tryCatch({
+    elinks_mixed <- entrez_link(dbfrom = "pubmed", id = c(19880848, 22883857), db = "all")
+    elinks_by_id <- entrez_link(dbfrom = "pubmed", id = c(19880848, 22883857), db = "all", by_id=TRUE)
+    all_the_commands <- lapply(commands, function(cmd_arg)
+        entrez_link(db="pubmed", dbfrom="pubmed", id=19880848, cmd=cmd_arg)
+    )
+    TRUE
+}, error = function(e) {
+    message("NCBI not available: ", conditionMessage(e))
+    FALSE
+})
 
-all_the_commands <- lapply(commands, function(cmd_arg)
-    entrez_link(db="pubmed", dbfrom="pubmed", id=19880848, cmd=cmd_arg)
-)
 test_that("The record-linking funcitons work",{
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_that(elinks_mixed, is_a("elink"))
     expect_that(names(elinks_mixed$links), is_a("character"))
     expect_true(length(elinks_mixed$links$pubmed_mesh_major) > 0)
@@ -25,12 +27,14 @@ test_that("The record-linking funcitons work",{
 
 
 test_that("by_id mode works for elinks", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_that(elinks_by_id, is_a("elink_list"))
     expect_that(length(elinks_by_id), equals(2))
     expect_that(elinks_by_id[[1]], is_a("elink"))
 })
 
 test_that("elink printing behaves", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_output(print(elinks_by_id), "List of 2 elink objects,each containing")
     for(ret in all_the_commands){
         expect_output(print(ret), "elink object with contents:\\s+\\$[A-Za-z]+")
@@ -39,13 +43,15 @@ test_that("elink printing behaves", {
 
 
 test_that("We detect missing ids from elink results",{
+   skip_if(!ncbi_ok, "NCBI not available")
    expect_warning(
     entrez_link(dbfrom="pubmed", db="all", id=c(20203609,2020360999999,20203610), by_id=TRUE)
    )
 })
 
 test_that("Elink sub-elements can be acessed and printed", {
-    expect_output(print(all_the_commands[[3]][[1]]), 
+    skip_if(!ncbi_ok, "NCBI not available")
+    expect_output(print(all_the_commands[[3]][[1]]),
                   "elink result with information from \\d+ databases")
     expect_output(print(all_the_commands[[8]]$linkouts[[1]]),
                   "Linkout from [ A-Za-z]+\\s+\\$Url")
@@ -53,6 +59,7 @@ test_that("Elink sub-elements can be acessed and printed", {
 
 
 test_that("URls can be extracted from elink objs", {
+   skip_if(!ncbi_ok, "NCBI not available")
    for(idx in 6:8){
        urls <- linkout_urls(all_the_commands[[idx]])
        expect_that(urls, is_a("list"))
@@ -61,8 +68,8 @@ test_that("URls can be extracted from elink objs", {
 })
 
 test_that("Elink errors on mis-spelled/unknown cmds",{
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_error(rcheck <- entrez_link(dbfrom = "pubmed",
-                                         id = 19880848, db = "all", 
+                                         id = 19880848, db = "all",
                                          cmd='rcheck'))
 })
-

--- a/tests/testthat/test_parse.r
+++ b/tests/testthat/test_parse.r
@@ -1,20 +1,26 @@
 context("result-parsers")
 
-
-raw_rec <- entrez_fetch(db="pubmed", id=20674752, rettype="xml")
-xml_rec <- entrez_fetch(db="pubmed", id=20674752, rettype="xml", parsed=TRUE)
-multi_rec <- entrez_fetch(db="pubmed", 
-                           id=c(22883857, 25042335, 20203609,11959827),
-                           rettype="xml", parsed=TRUE)
-parsed_raw <- parse_pubmed_xml(raw_rec)
-parsed_rec <- parse_pubmed_xml(xml_rec)
-parsed_multi <- parse_pubmed_xml(multi_rec)
-
-multi_pmid_eg <- parse_pubmed_xml(
-       entrez_fetch(db="pubmed", id='29743284', rettype="xml")
-)
+#setup (guarded so transient NCBI problems skip rather than abort the file)
+ncbi_ok <- tryCatch({
+    raw_rec <- entrez_fetch(db="pubmed", id=20674752, rettype="xml")
+    xml_rec <- entrez_fetch(db="pubmed", id=20674752, rettype="xml", parsed=TRUE)
+    multi_rec <- entrez_fetch(db="pubmed",
+                               id=c(22883857, 25042335, 20203609,11959827),
+                               rettype="xml", parsed=TRUE)
+    parsed_raw <- parse_pubmed_xml(raw_rec)
+    parsed_rec <- parse_pubmed_xml(xml_rec)
+    parsed_multi <- parse_pubmed_xml(multi_rec)
+    multi_pmid_eg <- parse_pubmed_xml(
+           entrez_fetch(db="pubmed", id='29743284', rettype="xml")
+    )
+    TRUE
+}, error = function(e) {
+    message("NCBI not available: ", conditionMessage(e))
+    FALSE
+})
 
 test_that("pubmed file parsers work",{
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_that(raw_rec, is_a("character"))
 
     expect_that(parsed_raw, is_a("pubmed_record"))
@@ -33,22 +39,21 @@ test_that("pubmed file parsers work",{
 
     # Bug #131 related to extracting all PMIDs from a pubmed xml that contained
     # references, not just the one true pm od teh artcle. Testing we don't
-    # regress 
+    # regress
 
     expect_that(length(multi_pmid_eg$pmid), equals(1))
 
 })
 
 test_that("we can print pubmed records", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_output(print(parsed_rec), "Pubmed record")
     expect_output(print(parsed_multi), "List of 4 pubmed records")
 })
 
 test_that("We warn about unknown pubmed record types", {
+    skip_if(!ncbi_ok, "NCBI not available")
     rec = entrez_fetch(db="pubmed", id=25905152, rettype="xml")
     expect_warning(parsed_rec <- parse_pubmed_xml(rec))
     expect_output(print(parsed_rec), "Pubmed record \\(empty\\)")
 })
-
-   
-   

--- a/tests/testthat/test_post.r
+++ b/tests/testthat/test_post.r
@@ -1,9 +1,18 @@
 context("entrez_post")
 
 prot_ids = c(15718680,157427902)
-ret <- entrez_post(id=prot_ids, db="protein")
+
+#setup (guarded so transient NCBI problems skip rather than abort the file)
+ncbi_ok <- tryCatch({
+    ret <- entrez_post(id=prot_ids, db="protein")
+    TRUE
+}, error = function(e) {
+    message("NCBI not available: ", conditionMessage(e))
+    FALSE
+})
 
 test_that("we can post ids", {
+    skip_if(!ncbi_ok, "NCBI not available")
     qk <- ret$QueryKey
     expect_that(as.integer(qk), is_a("integer"))
     expect_false(is.na(as.integer(qk)))
@@ -11,17 +20,19 @@ test_that("we can post ids", {
 })
 
 test_that("we can add to WebEnv", {
+    skip_if(!ncbi_ok, "NCBI not available")
     ret2 <- entrez_post(id=119703751, db="protein", web_history=ret)
     first <- entrez_summary(db="protein", web_history=ret)
     second <- entrez_summary(db="protein", web_history=ret2)
     expect_equal(ret2$QueryKey, "2")
     expect_equal(ret2$WebEnv, ret$WebEnv)
     expect_equal(length(first), 2)
-    expect_that(second, is_a("esummary"))#i.e. justone  
+    expect_that(second, is_a("esummary"))#i.e. justone
 })
 
 test_that("Example works", {
-     so_many_snails <- entrez_search(db="nuccore", 
+     skip_if(!ncbi_ok, "NCBI not available")
+     so_many_snails <- entrez_search(db="nuccore",
                            "Gastropoda[Organism] AND COI[Gene]", retmax=200)
      upload <- entrez_post(db="nuccore", id=so_many_snails$ids)
      first <- entrez_fetch(db="nuccore", rettype="fasta", web_history=upload, retstart=0, retmax=4)
@@ -30,6 +41,7 @@ test_that("Example works", {
 })
 
 test_that("We can print a post result", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_output(print(ret),
-     "\\(QueryKey = \\d+, WebEnv = [A-Z0-9_a-z]+\\.\\.\\.\\)") 
+     "\\(QueryKey = \\d+, WebEnv = [A-Z0-9_a-z]+\\.\\.\\.\\)")
 })

--- a/tests/testthat/test_query.r
+++ b/tests/testthat/test_query.r
@@ -1,49 +1,45 @@
 context("query")
 test_that("Query building functions work", {
 
-    #concatenate multiple IDs, include entrez terms 
-    query <- rentrez:::make_entrez_query("efetch", 
-                                         db="nuccore", 
-                                         id=c(443610374, 443610372),
-                                         config=list(),
-                                         retmode="txt",
-                                         rettype="fasta")
-    nrecs <- length(gregexpr(">", query)[[1]])
-   
-    expect_equal(nrecs, 2)
-    
+    setup <- tryCatch({
+        list(
+            #concatenate multiple IDs, include entrez terms
+            q_int = rentrez:::make_entrez_query("efetch",
+                                                db="nuccore",
+                                                id=c(443610374, 443610372),
+                                                config=list(),
+                                                retmode="txt",
+                                                rettype="fasta"),
+            #should be able to give ints or characters to id and get a url
+            q_chr = rentrez:::make_entrez_query("efetch",
+                                                db="nuccore",
+                                                id=c("443610374", "443610372"),
+                                                retmode="txt",
+                                                config=list(),
+                                                rettype="fasta")
+        )
+    }, error = function(e) skip(paste("NCBI not available:", conditionMessage(e))))
 
-    #should be able to give ints or characters to id and get a url
-    query <- rentrez:::make_entrez_query("efetch", 
-                                         db="nuccore", 
-                                         id=c("443610374", "443610372"),
-                                         retmode="txt",
-                                         config=list(),
-                                         rettype="fasta")
-    nrecs <- length(gregexpr(">", query)[[1]])
-    expect_equal(nrecs, 2)
+    expect_equal(length(gregexpr(">", setup$q_int)[[1]]), 2)
+    expect_equal(length(gregexpr(">", setup$q_chr)[[1]]), 2)
 
-    #specific function have right "require one of" settings
+    #specific function have right "require one of" settings (local validation)
     expect_that(entrez_fetch(db="nuccore", rettype="fasta"), throws_error())
     expect_that(entrez_summary(db="nuccore", web_history="A", id=123), throws_error())
     expect_that(entrez_link(db="nuccore", dbfrom="pubmed"), throws_error())
 
-    #httr pases on errors
-    #404
-    expect_error(rentrez:::make_entrez_query("non-eutil", 
-                                             id=12, 
+    #httr passes on errors: a request to a non-existent eutil should error (404)
+    expect_error(rentrez:::make_entrez_query("non-eutil",
+                                             id=12,
                                              db="none",
                                              config=list()))
-    #400
-    expect_error(rentrez:::make_entrez_query("efetch", 
-                                             id=1e-17,
-                                             config=list(),  
-                                             db="nuccore"))
-    
 })
 
 
 test_that("We give a useful error when an empty ID vector is passed", {
-    ET <- entrez_search(db="taxonomy", term="Extraterrestrial[Organism]")
-    expect_error(entrez_fetch(db="taxonomy", id= ET$ids, rettype="uilist"))              
+    ET <- tryCatch(
+        entrez_search(db="taxonomy", term="Extraterrestrial[Organism]"),
+        error = function(e) skip(paste("NCBI not available:", conditionMessage(e)))
+    )
+    expect_error(entrez_fetch(db="taxonomy", id= ET$ids, rettype="uilist"))
 })

--- a/tests/testthat/test_search.r
+++ b/tests/testthat/test_search.r
@@ -1,14 +1,21 @@
 context("search")
 
-#setup
-gsearch <- entrez_global_query("Heliconius")
-pubmed_search <- entrez_search(db = "pubmed", 
-                               term = "10.1016/j.ympev.2010.07.013[doi]")
-json_search <- entrez_search(db="pubmed", 
-                             term =  "10.1016/j.ympev.2010.07.013[doi]",
-                             retmode='json')
+#setup (guarded so transient NCBI problems skip rather than abort the file)
+ncbi_ok <- tryCatch({
+    gsearch <- entrez_global_query("Heliconius")
+    pubmed_search <- entrez_search(db = "pubmed",
+                                   term = "10.1016/j.ympev.2010.07.013[doi]")
+    json_search <- entrez_search(db="pubmed",
+                                 term =  "10.1016/j.ympev.2010.07.013[doi]",
+                                 retmode='json')
+    TRUE
+}, error = function(e) {
+    message("NCBI not available: ", conditionMessage(e))
+    FALSE
+})
 
 test_that("Global query works",{
+    skip_if(!ncbi_ok, "NCBI not available")
     #global query
     expect_that(gsearch, is_a("numeric"))
     expect_that(names(gsearch), is_a("character"))
@@ -18,12 +25,14 @@ test_that("Global query works",{
 })
 
 test_that("Entrez query works",{
+    skip_if(!ncbi_ok, "NCBI not available")
     #entrez query
     expect_that(pubmed_search, is_a("esearch"))
     expect_that(pubmed_search$ids, is_identical_to("20674752"))
 })
 
 test_that("Entrez query works just as well with xml/json",{
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_that(json_search, is_a("esearch"))
     expect_that(json_search$ids, is_identical_to("20674752"))
     expect_equal(names(pubmed_search),names(json_search))
@@ -31,6 +40,7 @@ test_that("Entrez query works just as well with xml/json",{
 
 
 test_that("we can print search results", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_output(print(pubmed_search), "Entrez search result with \\d+ hits")
     expect_output(print(json_search),   "Entrez search result with \\d+ hits")
 })

--- a/tests/testthat/test_summary.r
+++ b/tests/testthat/test_summary.r
@@ -2,14 +2,23 @@ context("fetching and parsing summary recs")
 
 fake_ids <- sample(1e5, 501)
 pop_ids = c("307082412", "307075396", "307075338", "307075274")
-pop_summ_xml <- entrez_summary(db="popset", 
-                               id=pop_ids, version="1.0")
-pop_summ_json <- entrez_summary(db="popset", 
-                                id=pop_ids, version="2.0")
-pop_summ_xml2 <- entrez_summary(db="popset", 
-                               id=pop_ids, version="1.0", retmode="xml")
+
+#setup (guarded so transient NCBI problems skip rather than abort the file)
+ncbi_ok <- tryCatch({
+    pop_summ_xml <- entrez_summary(db="popset",
+                                   id=pop_ids, version="1.0")
+    pop_summ_json <- entrez_summary(db="popset",
+                                    id=pop_ids, version="2.0")
+    pop_summ_xml2 <- entrez_summary(db="popset",
+                                   id=pop_ids, version="1.0", retmode="xml")
+    TRUE
+}, error = function(e) {
+    message("NCBI not available: ", conditionMessage(e))
+    FALSE
+})
 
 test_that("Functions to fetch summaries work", {
+          skip_if(!ncbi_ok, "NCBI not available")
           #tests
           expect_that(pop_summ_xml, is_a("list"))
           expect_that(pop_summ_json, is_a("list"))
@@ -18,25 +27,28 @@ test_that("Functions to fetch summaries work", {
           expect_that(pop_summ_json[[4]], is_a("esummary"))
           sapply(pop_summ_json, function(x)
                  expect_match(x[["title"]], "Muraenidae")
-          )         
-})  
+          )
+})
 
 
 
 test_that("List elements in XML are parsable", {
+         skip_if(!ncbi_ok, "NCBI not available")
          rec <- entrez_summary(db="pubmed", id=25696867, version="1.0")
          expect_named(rec$History)
          expect_gt(length(rec$History), 0)
 })
-         
+
 
 test_that("Version 2 xml records can be fetched and parsed", {
+    skip_if(!ncbi_ok, "NCBI not available")
     sapply(pop_summ_xml2, function(x)
                  expect_match(x[["Title"]], "Muraenidae"))
     expect_that(length(pop_summ_xml2[[1]]), is_more_than(12))
 })
 
 test_that("JSON and XML objects are similar", {
+          skip_if(!ncbi_ok, "NCBI not available")
           #It would be nice to test whether the xml and json records
           # have the same data in them, but it turns out they don't
           # when they leave the NCBI, so let's ensure we can get some
@@ -45,27 +57,30 @@ test_that("JSON and XML objects are similar", {
                  expect_match(x[["Title"]], "Muraenidae"))
           sapply(pop_summ_json, function(x)
                  expect_match(x[["title"]], "Muraenidae"))
-          
+
           expect_that(length(pop_summ_xml[[1]]), is_more_than(12))
           expect_that(length(pop_summ_json[[1]]), is_more_than(12))
-          
+
 })
 
 
 test_that("Error whent tring to fetch 1.0 summaries as json", {
+      skip_if(!ncbi_ok, "NCBI not available")
       expect_error(
         entrez_summary("pubmed", id = fake_ids[1:10], version="1.0", retmode="json")
       )
 })
 
 test_that("We can print summary records", {
-      expect_output(print(pop_summ_json), "List of  4 esummary records")        
-      expect_output(print(pop_summ_json[[1]]), "esummary result with \\d+ items")        
-      expect_output(print(pop_summ_xml), "List of  4 esummary records")        
-      expect_output(print(pop_summ_xml[[1]]), "esummary result with \\d+ items")        
+      skip_if(!ncbi_ok, "NCBI not available")
+      expect_output(print(pop_summ_json), "List of  4 esummary records")
+      expect_output(print(pop_summ_json[[1]]), "esummary result with \\d+ items")
+      expect_output(print(pop_summ_xml), "List of  4 esummary records")
+      expect_output(print(pop_summ_xml[[1]]), "esummary result with \\d+ items")
 })
 
 test_that("We can detect errors in esummary records", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_warning(
        entrez_summary(db="pmc", id=c(4318541212,4318541), version="1.0")
     )
@@ -73,36 +88,41 @@ test_that("We can detect errors in esummary records", {
        entrez_summary(db="pmc", id=c(4318541212,4318541))
     )
 })
-                         
+
 test_that("We can detect errors in esummary returns", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_error(
-       entrez_summary(db="pmc", id=fake_ids, version="2.0")       
+       entrez_summary(db="pmc", id=fake_ids, version="2.0")
     )
 })
 
 test_that("We can extract elements from esummary object", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_that(extract_from_esummary(pop_summ_xml, c("Title", "TaxId")), is_a("matrix"))
     expect_that(extract_from_esummary(pop_summ_xml, c("Title", "TaxId"), simplify=FALSE), is_a("list"))
     expect_that(extract_from_esummary(pop_summ_xml2, c("Title", "TaxId"), simplify=FALSE), is_a("list"))
     expect_that(extract_from_esummary(pop_summ_json, "title"), is_a("character"))
-   
+
 })
 
 test_that("We can extract elements from a single esummary", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_that(extract_from_esummary(pop_summ_xml[[1]], c("Title", "TaxId")), is_a("list"))
     expect_that(extract_from_esummary(pop_summ_xml[[1]], "Gi"), is_a("integer"))
     expect_that(extract_from_esummary(pop_summ_xml[[1]], "Gi", FALSE), is_a("list"))
 })
 
 test_that("We can get a list of one element if we ask for it", {
+    skip_if(!ncbi_ok, "NCBI not available")
     expect_that(entrez_summary(db="popset", id=307075396, always_return_list=TRUE), is_a("list"))
     expect_that(entrez_summary(db="popset", id=307075396), is_a("esummary"))
 })
 
 
 test_that("We can fetch summaries on versioned sequences", {
+    skip_if(!ncbi_ok, "NCBI not available")
     old_rec = entrez_summary(db="nuccore", id="AF123456.1")
     new_rec = entrez_summary(db="nuccore", id="AF123456.2")
     expect_match(old_rec$title, "testis-specific mRNA")
-    expect_match(new_rec$title, "doublesex and mab-3 related transcription factor")    
+    expect_match(new_rec$title, "doublesex and mab-3 related transcription factor")
 })


### PR DESCRIPTION
## Why

Once GitHub Actions CI started running the test suite (see #206), it surfaced that `master` had a broken test suite. The failures were a mix of one real regression, one outdated assertion, and live-API flakiness. This PR fixes the deterministic problems and makes the network tests resilient to NCBI hiccups.

## Changes

**1. Fix a regression in the documentation example test (`test_docs.r`).**
Commit 777da76 ("changes to address CRAN policies") accidentally changed `db="popset"` to a duplicate `term=` argument:
```r
entrez_search(term="Latrodectus katipo[Organism]", term="Latrodectus katipo[Organism]")
```
That throws `formal argument "term" matched by multiple actual arguments`. The README still uses the correct `db="popset"`. Restored it. This broke a year ago and went unnoticed because CI was not running.

**2. Remove a brittle assertion (`test_query.r`).**
A 2014 test expected `make_entrez_query()` to error on a malformed id (`1e-17`). NCBI no longer rejects that request, so the assertion fails. Removed it; the adjacent 404 (non-existent eutil) check still covers error propagation.

**3. Make live-API tests skip instead of abort on transient NCBI problems.**
Every networked test file did its setup at the top level, outside `test_that()`, so a single transient NCBI error (rate limiting, DNS failure, partial transfer, a temporarily unavailable database) aborted the whole file. Each setup block is now wrapped in `tryCatch` that records reachability, and each test starts with `skip_if(!ncbi_ok, ...)`. Transient NCBI issues now skip the affected tests rather than failing CI.

## Validation

Ran the full suite locally against the live NCBI API:

```
0 failed | 0 errors | 72 passed | 24 skipped
```

The skips were caused by NCBI intermittently rejecting the `popset` database during the run (esearch/esummary returned errors while efetch worked, and `popset` dropped out of `entrez_dbs()`). The new guards turn that into skips instead of failures, which is the intended behavior.

## Follow-up (not in this PR)

While validating, I found that `parse_esearch` crashes with a cryptic `subscript out of bounds` when NCBI returns an `<ERROR>` response (for example "Invalid db name specified: popset"), instead of surfacing NCBI's actual message. Worth a separate issue/fix (relates to #157 and #187).

## Relationship to #206

Independent of the CI workflow PR (#206), but complementary: #206 adds the workflows, this makes the suite they run reliable.