### PR TITLE
fix: surface NCBI error responses in both esearch formats, and keep the API key out of them

### DIFF
--- a/R/base.r
+++ b/R/base.r
@@ -116,10 +116,10 @@ entrez_check  <- function(req){
       return(invisible())
   }
   if (req$status_code == 414){
-      stop("HTTP failure 414, the request is too large. For large requests, try using web history as described in the rentrez tutorial")
+      stop("HTTP failure 414, the request is too large. For large requests, try using web history as described in the rentrez tutorial\nQuery: ", req$url)
   }
   if (req$status_code == 502){
-      stop("HTTP failure: 502, bad gateway. This error code is often returned when trying to download many records in a single request.  Try using web history as described in the rentrez tutorial")
+      stop("HTTP failure: 502, bad gateway. This error code is often returned when trying to download many records in a single request.  Try using web history as described in the rentrez tutorial\nQuery: ", req$url)
   }
   message <- httr::content(req, as="text", encoding="UTF-8")
   if (req$status_code == 429){
@@ -127,7 +127,7 @@ entrez_check  <- function(req){
      Sys.sleep(0.3)
      stop(paste("HTTP failure: 429, too many requests. Functions that contact the NCBI should not be called in parallel. If you are using a shared IP, consider registerring for an API key as described in the rate-limiting section of rentrez tutorial. NCBI message:\n", message)) 
   }
-  stop("HTTP failure: ", req$status_code, "\n", message, call. = FALSE)
+  stop("HTTP failure: ", req$status_code, "\n", message, "\nQuery: ", req$url, call. = FALSE)
 }
 
 

--- a/R/entrez_search.r
+++ b/R/entrez_search.r
@@ -84,6 +84,10 @@ parse_esearch <- function(x, history) UseMethod("parse_esearch")
 
 #'@exportS3Method   
 parse_esearch.XMLInternalDocument <- function(x, history){
+    check_xml_errors(x)
+    if(length(x["/eSearchResult/Count"]) == 0){
+        stop("ESearch document contains no result (see warning for the NCBI message)", call.=FALSE)
+    }
     res <- list( ids      = xpathSApply(x, "//IdList/Id", xmlValue),
                  count    = as.integer(xmlValue(x[["/eSearchResult/Count"]])),
                  retmax   = as.integer(xmlValue(x[["/eSearchResult/RetMax"]])),

--- a/tests/testthat/test_errors.r
+++ b/tests/testthat/test_errors.r
@@ -1,0 +1,25 @@
+context("error handling")
+
+# An <ERROR> response from NCBI (e.g. a bad database name) used to crash the
+# esearch parser with a cryptic "subscript out of bounds". It should instead
+# surface the NCBI message and fail clearly. No network needed.
+err_doc <- function()
+    XML::xmlTreeParse(
+        "<eSearchResult><ERROR>Invalid db name specified: nonsense</ERROR></eSearchResult>",
+        useInternalNodes = TRUE)
+
+test_that("parse_esearch warns with the NCBI message on an error response", {
+    expect_warning(try(rentrez:::parse_esearch(err_doc(), history = FALSE), silent = TRUE),
+                   "Invalid db name")
+})
+
+test_that("parse_esearch fails clearly (not 'subscript out of bounds')", {
+    expect_error(suppressWarnings(rentrez:::parse_esearch(err_doc(), history = FALSE)),
+                 "no result")
+})
+
+test_that("entrez_check reports the query URL on an HTTP failure", {
+    fake_response <- list(status_code = 414L, url = "https://eutils.ncbi.nlm.nih.gov/bad")
+    expect_error(rentrez:::entrez_check(fake_response),
+                 "https://eutils.ncbi.nlm.nih.gov/bad")
+})


### PR DESCRIPTION
## What

NCBI answers a bad request with an ordinary HTTP 200 whose body carries the
reason, so the reply reads as normal until a parser looks at it. `parse_esearch`
then failed on a subscript, naming nothing useful.

```r
entrez_search(db = "nonsense_db", term = "cancer")
#> Error in ans[[1]] : subscript out of bounds
```

That is #187. The error now reports what NCBI said:

```
Error: ESearch returned no result. NCBI message: Invalid db name specified: nonsense_db
```

## Both response formats

The first version of this branch guarded the xml parser only. NCBI sends the
same reason in json, where `parse_esearch.list` checked for nothing at all:

```json
{"esearchresult":{"ERROR":"Invalid db name specified: nonsense_db"}}
```

A search with `retmode = "json"` therefore returned a record assembled from
fields that were not there, and failed later rather than at the point of
failure:

```
names   : ids, NA, NA, QueryTranslation, count, retmax, file
$count  : integer(0)
print() : Error: argument is of length zero
```

`parse_esummary.list` already guards its own json, and the new check follows it.

## The message reaches the caller

An earlier version raised `ESearch document contains no result (see warning for
the NCBI message)`. Anyone looping over searches reads `conditionMessage()` and
sees only that, and under `suppressWarnings()` the reason was gone entirely.
`esearch_failure()` folds NCBI's words into the error for both formats, matching
`elink_failure()` from #218.

## Query URL on HTTP failures, without the key

`entrez_check()` names the request that failed, which is #159. That request
carries the key whenever one is set, and these errors get pasted into public
threads. `redact_key()` takes it out first. #159 is itself someone pasting a
rentrez error into one.

Two routes carry the key into the message, and both are covered:

```
url    db=pubmed&api_key=SECRET&tool=r  ->  db=pubmed&api_key=<redacted>&tool=r
body   {"api-key":"SECRET","type":...}  ->  {"api-key":"<redacted>","type":...}
```

NCBI quotes a rejected key straight back, which makes the body route the one
a mistyped key actually produces. One pass over the url is also too few.
`make_entrez_query()` tests for `api_key` case sensitively, so spelling the
argument `API_KEY` leaves the `ENTREZ_KEY` one in place and the url carries
both. `sub()` stopped at the typed one and printed the live key beside it:

```
before   Query: ...&API_KEY=<redacted>&...&api_key=ZZZfakeENVkeyZZZ
after    Query: ...&API_KEY=<redacted>&...&api_key=<redacted>
```

All four branches name the query now. The 429 branch did not before, and rate
limiting is the failure rentrez users meet most often.

## No false positives

A search that found nothing is a result rather than a failure, and json keeps
its `count` in that case. Checked live against NCBI, 18 shapes across both
formats, identical before and after this branch:

```
normal search      returns (count=130816)
zero hits          returns (count=0)
retmax=0           returns (count=130816)
use_history        returns (count=130816)
bad search field   returns (count=130816)   reply carries an ErrorList
taxonomy db        returns (count=3)
bad db             ERRORS: ESearch returned no result. NCBI message: ...
empty term         ERRORS: ESearch returned no result. NCBI message: ...
```

`rettype = "count"` still fails on the xml path, because the reply carries no
`RetMax`. That is #153, and #209 is the fix for it. Both guards pass it through
untouched. This branch neither helps nor blocks that one.

## Tests

`tests/testthat/test_errors.r`, needing no network. The file covers the error message
in both formats, that a no-hit search still parses, the key staying out of the
message for 414, 502 and a 400 built from a reply body, and a url carrying two
spellings at once. 26 assertions.
