### PR TITLE
fix: parse and print count-only searches, and keep by_id a list for one id

### DIFF
--- a/R/entrez_link.r
+++ b/R/entrez_link.r
@@ -106,7 +106,8 @@ parse_elink <- function(x, cmd, by_id, id){
     check_xml_errors(x)
     f <- make_elink_fxn(cmd)
     res <-  xpathApply(x, "//LinkSet",f)
-    if(length(res) > 1){
+    #in by_id mode always return a list, one elink per id, even for a single id
+    if(by_id || length(res) > 1){
         class(res) <- c("elink_list", "list")
         return(res)
     }

--- a/R/entrez_search.r
+++ b/R/entrez_search.r
@@ -88,10 +88,13 @@ parse_esearch.XMLInternalDocument <- function(x, history){
     if(length(x["/eSearchResult/Count"]) == 0){
         stop("ESearch document contains no result (see warning for the NCBI message)", call.=FALSE)
     }
+    #some responses (e.g. rettype="count") omit RetMax/QueryTranslation, so
+    #pull the scalar fields safely rather than indexing a missing node
+    get1 <- function(xpath){ node <- x[xpath]; if(length(node)) xmlValue(node[[1]]) else NA }
     res <- list( ids      = xpathSApply(x, "//IdList/Id", xmlValue),
-                 count    = as.integer(xmlValue(x[["/eSearchResult/Count"]])),
-                 retmax   = as.integer(xmlValue(x[["/eSearchResult/RetMax"]])),
-                 QueryTranslation   = xmlValue(x[["/eSearchResult/QueryTranslation"]]),
+                 count    = as.integer(get1("/eSearchResult/Count")),
+                 retmax   = as.integer(get1("/eSearchResult/RetMax")),
+                 QueryTranslation   = get1("/eSearchResult/QueryTranslation"),
                  file     = x)
     if(history){
         res$web_history = web_history(

--- a/tests/testthat/test_errors.r
+++ b/tests/testthat/test_errors.r
@@ -23,3 +23,13 @@ test_that("entrez_check reports the query URL on an HTTP failure", {
     expect_error(rentrez:::entrez_check(fake_response),
                  "https://eutils.ncbi.nlm.nih.gov/bad")
 })
+
+# A count-only response (rettype="count") has a Count but no RetMax/IdList,
+# which used to crash the parser. No network needed.
+test_that("parse_esearch handles a count-only response", {
+    doc <- XML::xmlTreeParse("<eSearchResult><Count>5648701</Count></eSearchResult>",
+                             useInternalNodes = TRUE)
+    res <- rentrez:::parse_esearch(doc, history = FALSE)
+    expect_equal(res$count, 5648701L)
+    expect_true(is.na(res$retmax))
+})

--- a/tests/testthat/test_link_byid.r
+++ b/tests/testthat/test_link_byid.r
@@ -1,0 +1,14 @@
+context("elink by_id")
+
+# In by_id mode the result should always be a list (one elink per id), even for
+# a single id, and the call should not emit a spurious "invalid id" warning.
+test_that("by_id=TRUE returns a one-element list with no spurious warning", {
+    res <- tryCatch(
+        expect_warning(
+            entrez_link(db="protein", dbfrom="gene", id="93100", by_id=TRUE),
+            NA),
+        error = function(e) skip(paste("NCBI not available:", conditionMessage(e)))
+    )
+    expect_that(res, is_a("elink_list"))
+    expect_equal(length(res), 1)
+})


### PR DESCRIPTION
Two small, independent fixes, in the existing style.

## 1. `rettype="count"` parses, and now prints (#153)

A count-only reply carries a `Count` and nothing else:

```xml
<eSearchResult><Count>5648701</Count></eSearchResult>
```

`parse_esearch()` indexed the missing nodes directly and died with `subscript
out of bounds`. It reads the scalar fields safely now:

```r
get1 <- function(xpath){ node <- x[xpath]; if(length(node)) xmlValue(node[[1]]) else NA_character_ }
```

Parsing turned out to be half the problem. `print.esearch()` read
`QueryTranslation` without checking, and that field is exactly what these
replies leave out. Such a result came back fine and then died the moment anyone
looked at it:

```r
entrez_search(db = "pubmed", term = "Drosophila", rettype = "count")
#> Error in if (nchar(x$QueryTranslation) > 50) { :
#>   missing value where TRUE/FALSE needed
```

Each format reaches that line by its own route. The xml path leaves the field
`NA` and the json path leaves it zero-length, and `is.na()` on a zero-length
value answers `logical(0)` rather than `FALSE`, so the length test comes first.

Worth knowing: the json half of this predates the count-only work. json has
always parsed these replies and has never once been able to print one.

`use_history` is the same story one argument along. NCBI ignores it for a
count-only search and sends back the same bare reply:

```xml
<eSearchResult> <Count>130816</Count> </eSearchResult>
```

There is no QueryKey and no WebEnv to attach. Rather than assemble a
`web_history` out of two absent fields, the search says what happened and
attaches nothing:

```
Warning: NCBI returned no web history for this search, so none is attached.
A count-only search carries none.
```

## 2. `by_id=TRUE` with one id returns a list, and warns about nothing (#175)

`parse_elink()` took `by_id` and ignored it, and a single `LinkSet` collapsed
to a bare `elink` rather than a one-element `elink_list`. That also tripped the
`length(res) != length(id)` check and produced a "Some IDs appear to be
invalid" warning over data that was perfectly good.

Order matters here, and the first version of this got it wrong. Testing `by_id`
before testing for an empty result let `by_id=TRUE` hand back an empty
`elink_list` where every other path reports what NCBI said, which is the
failure #215 exists to prevent, reached through a different door. The empty
check runs ahead of it now:

```r
res <- xpathApply(x, "//LinkSet", f)
if(length(res) == 0){ stop(elink_failure("ELink returned no LinkSet", x), call.=FALSE) }
if(by_id || length(res) > 1){ class(res) <- c("elink_list","list"); return(res) }
res[[1]]
```

```
                by_id=FALSE            by_id=TRUE
no LinkSet      reports NCBI's error   reports NCBI's error
one LinkSet     elink                  elink_list, length 1
two LinkSets    elink_list, length 2   elink_list, length 2
```

## Tests

`test_errors.r` covers the count-only parse, the print in both formats, and the
`use_history` warning, none of it needing the network. `test_link_byid.r`
covers the single-id case against live NCBI and, offline, that `by_id=TRUE`
still reports a reply carrying no LinkSet.

Every one of these fails when its fix is reverted, which is worth stating
because the first version of the live test did not. It wrapped its expectations
in `tryCatch(error = skip)`, and a testthat failure is an error condition.
That test could only ever pass or skip. Only the call is wrapped now.

## Checked

Rebased onto master after #208 and #225. The guards #208 added still fire ahead
of the count-only path. A reply carrying no result at all still stops with
NCBI's own message rather than passing as a count of nothing:

```
xml/json count-only   parses and prints
xml/json zero hits    unchanged, full output
xml/json normal       unchanged, full output
xml/json bad db       errors: ESearch returned no result. NCBI message: ...
```

`QueryTranslation` and `retmax` now carry the types the help page documents on
both paths, where a count-only reply previously made the first of them logical.
77 offline assertions pass, and both fixes were confirmed against live NCBI.
