### PR TITLE
Handle count-only Entrez search responses

### DIFF
--- a/R/entrez_search.r
+++ b/R/entrez_search.r
@@ -84,8 +84,16 @@ parse_esearch <- function(x, history) UseMethod("parse_esearch")
 
 #'@exportS3Method   
 parse_esearch.XMLInternalDocument <- function(x, history){
+    count <- as.integer(xmlValue(x[["/eSearchResult/Count"]]))
+    count_only <- length(xpathSApply(x, "/eSearchResult/RetMax", xmlValue)) == 0 &&
+                  length(xpathSApply(x, "/eSearchResult/QueryTranslation", xmlValue)) == 0
+    if(count_only){
+        res <- list(count = count, file = x)
+        class(res) <- c("esearch", "list")
+        return(res)
+    }
     res <- list( ids      = xpathSApply(x, "//IdList/Id", xmlValue),
-                 count    = as.integer(xmlValue(x[["/eSearchResult/Count"]])),
+                 count    = count,
                  retmax   = as.integer(xmlValue(x[["/eSearchResult/RetMax"]])),
                  QueryTranslation   = xmlValue(x[["/eSearchResult/QueryTranslation"]]),
                  file     = x)
@@ -101,6 +109,14 @@ parse_esearch.XMLInternalDocument <- function(x, history){
 
 #'@exportS3Method   
 parse_esearch.list <- function(x, history){
+    result_names <- names(x$esearchresult)
+    count_only <- "count" %in% result_names &&
+                  !any(c("idlist", "retmax", "querytranslation") %in% result_names)
+    if(count_only){
+        res <- list(count = as.integer(x$esearchresult$count), file = x)
+        class(res) <- c("esearch", "list")
+        return(res)
+    }
     #for consitancy between xml/json records we are going to change the
     #file names from lower -> CamelCase
     res <- x$esearchresult[ c("idlist", "count", "retmax", "querytranslation") ]
@@ -118,6 +134,10 @@ parse_esearch.list <- function(x, history){
 
 #'@export
 print.esearch <- function(x, ...){
+    if(is.null(x$QueryTranslation)){
+        cat(paste("Entrez search result with", x$count, "hits\n"))
+        return(invisible(x))
+    }
     display_term <- if(nchar(x$QueryTranslation) > 50){
         paste(substr(x$QueryTranslation, 1, 50), "...")
     } else x$QueryTranslation

--- a/tests/testthat/test_search_count.r
+++ b/tests/testthat/test_search_count.r
@@ -1,0 +1,23 @@
+context("count-only search responses")
+
+test_that("count-only search responses are parsed and printed", {
+    xml <- XML::xmlParse(paste0(
+        "<eSearchResult>",
+        "<Count>42</Count>",
+        "</eSearchResult>"
+    ))
+    json <- list(
+        header = list(type = "esearch", version = "0.3"),
+        esearchresult = list(count = "42")
+    )
+
+    xml_search <- parse_esearch(xml, history = FALSE)
+    json_search <- parse_esearch(json, history = FALSE)
+
+    expect_equal(xml_search$count, 42L)
+    expect_equal(json_search$count, 42L)
+    expect_named(xml_search, c("count", "file"))
+    expect_named(json_search, c("count", "file"))
+    expect_output(print(xml_search), "Entrez search result with 42 hits")
+    expect_output(print(json_search), "Entrez search result with 42 hits")
+})


### PR DESCRIPTION
## Summary

Handle NCBI's count-only ESearch response in both XML and JSON modes.

## Thanks to maintainers

Thanks for maintaining rentrez and for inviting a pull request on #153.

## Issue or motivation

`entrez_search(..., rettype = "count")` currently errors for XML responses and creates an object that cannot be printed for JSON responses.

Closes #153.

## Root cause

Count-only responses omit the ID list, return limit, and translated query fields, but both parsers and `print.esearch()` assumed those fields were always present.

## Change

Detect the count-only response shape, return an `esearch` object containing the count and original response, and print the count without expecting query metadata. Add offline regression coverage for XML and JSON.

## Tests

- Count-only parser test: 6 expectations passed
- Live XML and JSON count requests, including count parity with a regular search
- `R CMD build .`
- `R CMD check --no-manual rentrez_1.2.4.tar.gz` (`Status: OK`)
- `NOT_CRAN=true` full suite: the new test passes; the same five unrelated API/stale-test failures reproduce on unmodified `master`

## Scope

Regular ESearch parsing, request construction, and other EUtils endpoints are unchanged.
