### PR TITLE
Fix stray characters in two error messages and an .Rbuildignore pattern

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,6 +11,6 @@
 ^README-*\.png$
 ^CONDUCT\.md$
 ^.github$
-^revdep$/
+^revdep/
 ^doc$
 ^Meta$

--- a/R/entrez_summary.r
+++ b/R/entrez_summary.r
@@ -165,7 +165,7 @@ parse_esummary.XMLInternalDocument  <- function(x, version, always_return_list){
         recs <- x["//DocSum"] 
 
         if(length(recs)==0){
-           stop("Esummary document contains no DocSums, try 'version=2.0'?)")
+           stop("Esummary document contains no DocSums, try 'version=2.0'?")
         }
         per_rec <- function(r){
             res <- xpathApply(r, "Item", parse_node)

--- a/R/parse_pubmed_xml.r
+++ b/R/parse_pubmed_xml.r
@@ -38,7 +38,7 @@ parse_one_pubmed <- function(paper){
     if( atype != "PubmedArticle" ){
         pmid = xpathSApply(paper, "//PMID", xmlValue)
         msg = paste0("Pubmed record ", pmid, " is of type '", atype, 
-                     "' which  rentrez doesn't know how to parse.",
+                     "' which rentrez doesn't know how to parse.",
                      " Returning empty record")
 
         warning(msg)


### PR DESCRIPTION
Three small, self-contained fixes. Text and build-config only — no change to package behaviour, and no new tests since there is no logic to exercise.

### 1. Stray `)` in an `entrez_summary()` error message

`R/entrez_summary.r` — the message printed as:

```
Esummary document contains no DocSums, try 'version=2.0'?)
```

with an orphaned closing paren. Now ends at the `?`.

### 2. Double space in a `parse_pubmed_xml()` warning

`R/parse_pubmed_xml.r` — `"' which  rentrez doesn't know how to parse."` had two spaces after `which`.

### 3. `.Rbuildignore` pattern that never matched

`^revdep$/` is not a meaningful pattern: the `$` anchors end-of-string before the `/`, so it matches nothing. The intent was clearly to ignore a `revdep/` directory, so this is now `^revdep/`. No `revdep/` directory exists in the repo today, so this is a correctness tidy rather than a live bug fix.

### Notes for review

* CRAN is currently OK on 1.2.4 across all 13 flavours, so none of this is check-driven — it is discretionary cleanup.
* Deliberately scoped to avoid overlap with the open PRs: the `R/base.r` comment typos are already covered by #164, and the `CONDUCT.md` / `CONTRIBUTING.md` fixes by #138. `.Rbuildignore` is also edited by #138 and #206, but neither touches the `revdep` line, so this should merge cleanly.
