### PR TITLE
Restore db="popset" in the documentation example test

### DIFF
--- a/tests/testthat/test_docs.r
+++ b/tests/testthat/test_docs.r
@@ -6,7 +6,7 @@ context("documentation")
 test_that("Examples in documentation work", {
     #setup
     hox_paper <- entrez_search(db="pubmed", term="10.1038/nature08789[doi]")
-    katipo_search <- entrez_search(term="Latrodectus katipo[Organism]", 
+    katipo_search <- entrez_search(db="popset",
                                    term="Latrodectus katipo[Organism]")
     
 


### PR DESCRIPTION
One-line fix for a test that currently fails on every run.

### The bug

`777da76` ("changes to address CRAN policies") replaced the `db` argument with a duplicate `term` argument in `tests/testthat/test_docs.r`:

```r
katipo_search <- entrez_search(term="Latrodectus katipo[Organism]",
                               term="Latrodectus katipo[Organism]")
```

R rejects a duplicate named argument before the function body runs, so this errors deterministically, with no network involved:

```
formal argument "term" matched by multiple actual arguments
```

`test_docs.r` has therefore been failing on `master` since June 2025. It went unnoticed because Travis had already stopped running by then, and CRAN does not run this file (1.2.4 is currently OK on all 13 flavours).

### The fix

Restore `db="popset"`. This matches the README example the test exists to mirror (`README.Rmd` line 117):

```r
katipo_search <- entrez_search(db="popset", term="Latrodectus katipo[Organism]")
```

### Verification

Verified locally under R 4.6.1 that the file parses and the call's argument matching now succeeds against the real `entrez_search()` signature.

**Not** verified: the assertion itself (`katipo_search$count >= 6`) makes a live NCBI call, which I could not exercise locally. The crash is definitely gone; the assertion's outcome will be confirmed the first time the suite runs against the API.

### Relationship to #206

#206 fixes this same line as part of a broader test-suite refactor, so **merging this PR will make #206 conflict on `tests/testthat/test_docs.r`**. The resolution is trivial: take #206's version, which contains this same `db="popset"` fix plus a `tryCatch`/`skip_if` wrapper.

The case for landing this separately is that it makes `master` green in one reviewable line, without waiting on a 22-file PR. If you would rather avoid the conflict entirely, close this and let #206 carry the fix.
